### PR TITLE
Update nickel URL to point at language homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@ jobs:
 
 # 💭 Alternative options and approaches to DevOps (cough yamlops cough) 💭
 # - https://media.ccc.de/v/36c3-11172-leaving_legacy_behind
-# - https://github.com/tweag/nickel
+# - https://nickel-lang.org/
 # - https://dhall-lang.org/
 # - https://cuelang.org/
 # - https://jsonnet.org/


### PR DESCRIPTION
Nice site!

The link for nickel is pointing to tweag's github repo. They've recently created a homepage which seems like a better link to include here and matches the convention for the other config languages in this list of pointing to the homepage instead of the source repo.