### PR TITLE
Add an extra YAML footgun

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,13 @@ WHERE EXISTS:
       - price
       - 50	
 
+# Speaking of CI, did you know that 8-character SHAs could be all numbers?
+my:
+	# this will be a string ~98% of the time
+	flaky_version: ${GIT_SHORT_SHA}
+	# this will be a string ~100% of the time
+	string_version: "${GIT_SHORT_SHA}"
+
 # him: "Look, I bought a box of DevOps"
 # her: "You can't just buy a box of DevOps"
 # 🤣 https://twitter.com/mike_kaufmann/status/1454712996933025794

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@ WHERE EXISTS:
       - 50	
 
 # Speaking of CI, did you know that 8-character SHAs could be all numbers?
+# If the system that parses `my.flaky_version` is typed, it will happily explode 2% of the time.
 my:
 	# this will be a string ~98% of the time
 	flaky_version: ${GIT_SHORT_SHA}


### PR DESCRIPTION
This comes from memory when using `GIT_SHORT_SHA` in CI to tag a Docker image. If, through unlucky circumstances, your `GIT_SHORT_SHA` is all numbers (which happens `10^8 / 16^8` percent of the time) then the SHA will be parsed as a number and not a string. Typed systems which then use this value (e.g. basically everything written in Go) will promptly explode when given such a non-string.