### PR TITLE
Added 07/08 example

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,12 @@ NI: Nicaragua
 NL: Netherlands
 NO: Norway # 💣!
 
+# 🚨 Anyone wondering why their first seven Kubernetes clusters deploy just fine, and the eighth fails? 🚨
+- 07
+- 08
+# Results in
+[ 7, "08" ]
+
 # YAML knows that, when you have something that looks like the time of day,
 # what you _really_ wanted is the time of seconds since midnight
 timeOfDay:


### PR DESCRIPTION
From hackernews -
> This is my favourite turd:
> 
>   - 07
>   - 08
>
> Results in
>
>  [ 7, "08" ]
>
> due to assumptions about octal and strings.
>
> This assumption was discovered deep within some templated YAML generated by templated something else three levels down and resulted in a complete k8s cluster failure for us, but only the 08 cluster! It worked in the first 7. 