### PR TITLE
Update invalid no longer existing matrix.yaml.io to use new domain at matrix.yaml.info

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@ jobs:
 # 👉 https://twitter.com/colmmacc/status/1063470541464461312 👈
 #
 # "Every YAML parser is a custom YAML parser"
-# 👉 https://matrix.yaml.io/valid.html 👈
+# 👉 https://matrix.yaml.info/valid.html 👈
 #
 # "There are 63 different ways to write multi-line strings in YAML"
 # 👉 https://stackoverflow.com/a/21699210/1094085 👈


### PR DESCRIPTION
The link to https://matrix.yaml.io/valid.html is broken, based on archive.org (https://web.archive.org/web/20220926032413/https://matrix.yaml.io/valid.html) it appears to have moved some time in 2022 to https://matrix.yaml.info/valid.html (and then of course a few years later the old site with the message saying it moved as stopped working).