### PR TITLE
and yaml version note on hours conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@ NO: Norway # 💣!
 # YAML knows that, when you have something that looks like the time of day,
 # what you _really_ wanted is the time of seconds since midnight
 timeOfDay:
-  whatYouWrote: 04:30 # And when you parse this file and serialize it again, you get ...
+  whatYouWrote: 04:30 # And when you parse this file and serialize it again, you may get before YAML 1.2 ...
   whatYouSurelyMeant: 16200 # Have fun debugging this one!
   whatYouShouldHaveWritten: !!str 04:30
 


### PR DESCRIPTION
I got nerd-sniped by the implicit time conversion issue, and I searched more about it.

So, I tested a few parsers, but none of them converted an unquoted value like `04:30` into seconds - even when using the wrapped `go-yaml` package that Kubernetes relies on: https://go.dev/play/p/j2kRfGM6sSZ

[Looking at the version history](https://yaml.org/spec/1.2.2/ext/changes/), YAML 1.2 dropped the `!!timestamp` type. So, any modern YAML parser won't perform this weird conversion anymore.

This PR simply adds a note mentioning that before YAML 1.2, this implicit conversion _may_ happen.
(I added the "may" here because some parsers, like `go-yaml`, mostly follow YAML 1.1 but selectively skip features)

Please, let me know what you think